### PR TITLE
update to gradle plugin 3.0.1 to have google() method available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:2.3.3"
+        classpath "com.android.tools.build:gradle:3.0.1"
     }
 }
 
@@ -16,14 +17,14 @@ repositories {
 apply plugin: "com.android.application"
 
 dependencies {
-    compile "com.android.support:support-compat:27.1.0"
-    compile "com.android.support:support-core-ui:27.1.0"
-    compile "com.android.support:appcompat-v7:27.1.0"
-    compile "com.android.support:recyclerview-v7:27.1.0"
-    compile "com.android.support:support-annotations:27.1.0"
-    compile "com.android.support:design:27.1.0"
-    compile "com.crossbowffs.remotepreferences:remotepreferences:0.5"
-    provided "de.robv.android.xposed:api:53"
+    implementation "com.android.support:support-compat:27.1.0"
+    implementation "com.android.support:support-core-ui:27.1.0"
+    implementation "com.android.support:appcompat-v7:27.1.0"
+    implementation "com.android.support:recyclerview-v7:27.1.0"
+    implementation "com.android.support:support-annotations:27.1.0"
+    implementation "com.android.support:design:27.1.0"
+    implementation "com.crossbowffs.remotepreferences:remotepreferences:0.5"
+    compileOnly "de.robv.android.xposed:api:53"
 }
 
 android {


### PR DESCRIPTION
This fixes:

> Could not find method google() for arguments [] on repository
container.