### PR TITLE
Add settings that can block all incoming SMS from unknown numbers and alphanumeric senders by default

### DIFF
--- a/app/src/main/java/com/crossbowffs/nekosms/consts/PreferenceConsts.java
+++ b/app/src/main/java/com/crossbowffs/nekosms/consts/PreferenceConsts.java
@@ -10,6 +10,10 @@ public final class PreferenceConsts {
 
     public static final String KEY_ENABLE = "pref_enable";
     public static final boolean KEY_ENABLE_DEFAULT = true;
+    public static final String KEY_BLACKLIST_SENDER_ID_ALPHANUMERIC = "pref_blacklist_sender_id_alphanumeric";
+    public static final boolean KEY_BLACKLIST_SENDER_ID_ALPHANUMERIC_DEFAULT = false;
+    public static final String KEY_BLACKLIST_SENDER_ID_PHONE = "pref_blacklist_sender_id_phone";
+    public static final boolean KEY_BLACKLIST_SENDER_ID_PHONE_DEFAULT = false;
     public static final String KEY_WHITELIST_CONTACTS = "pref_whitelist_contacts";
     public static final boolean KEY_WHITELIST_CONTACTS_DEFAULT = false;
     public static final String KEY_NOTIFICATIONS_ENABLE = "pref_notifications_enable";

--- a/app/src/main/java/com/crossbowffs/nekosms/utils/SenderIdUtils.java
+++ b/app/src/main/java/com/crossbowffs/nekosms/utils/SenderIdUtils.java
@@ -1,0 +1,29 @@
+package com.crossbowffs.nekosms.utils;
+
+import java.util.regex.Pattern;
+
+public final class SenderIdUtils {
+
+    private static final Pattern REGEX_PATTERN_GENERAL_PHONE_NUMBER = Pattern.compile("^[+]*\\d*[(\\s-]{0,2}[0-9]{1,4}[)]{0,1}[-\\s./0-9]*$");
+    private static final String REGEX_REMOVE_NON_DIGITS = "[^0-9]";
+    private static final int PHONE_NUMBER_DIGITS_MIN = 3;
+    private static final int PHONE_NUMBER_DIGITS_MAX = 15;
+
+    private SenderIdUtils() {}
+
+    public static boolean isSenderIdAlphanumeric(String senderId) {
+        return !isValidPhoneNumber(senderId);
+    }
+
+    public static boolean isSenderIdPhone(String senderId) {
+        return isValidPhoneNumber(senderId);
+    }
+
+    private static boolean isValidPhoneNumber(String senderId) {
+        int numberOfDigits = senderId.replaceAll(REGEX_REMOVE_NON_DIGITS, "").length();
+        if (numberOfDigits < PHONE_NUMBER_DIGITS_MIN || numberOfDigits > PHONE_NUMBER_DIGITS_MAX) {
+            return false;
+        }
+        return REGEX_PATTERN_GENERAL_PHONE_NUMBER.matcher(senderId).matches();
+    }
+}

--- a/app/src/main/java/com/crossbowffs/nekosms/xposed/SmsHandlerHook.java
+++ b/app/src/main/java/com/crossbowffs/nekosms/xposed/SmsHandlerHook.java
@@ -182,11 +182,11 @@ public class SmsHandlerHook implements IXposedHookLoadPackage {
         Context context = (Context)param.args[1];
         if (mContext == null) {
             mContext = context;
-            mFilterLoader = new SmsFilterLoader(context);
             mPreferences = new RemotePreferences(context,
                 PreferenceConsts.REMOTE_PREFS_AUTHORITY,
                 PreferenceConsts.FILE_MAIN,
                 true);
+            mFilterLoader = new SmsFilterLoader(context, mPreferences);
             grantWriteSmsPermissions(context);
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,6 +135,10 @@
     <string name="pref_enable">Enable NekoSMS</string>
     <string name="pref_enable_summary">No reboot required</string>
     <string name="pref_enable_summary_alt">Please enable the Xposed module first!</string>
+    <string name="pref_blacklist_sender_id_alphanumeric">Blacklist alphanumeric senders</string>
+    <string name="pref_blacklist_sender_id_alphanumeric_summary">Block all incoming messages from non-phone-number senders by default. Typically - enterprise notifications and advertising mailings. Exceptions can be manually added as whitelist rules</string>
+    <string name="pref_blacklist_sender_id_phone">Blacklist phone number senders</string>
+    <string name="pref_blacklist_sender_id_phone_summary">Block all incoming messages from any phone number by default, except explicitly whitelisted</string>
     <string name="pref_whitelist_contacts">Whitelist contacts</string>
     <string name="pref_whitelist_contacts_summary">Don\'t block messages from contacts</string>
     <string name="pref_verbose_logging">Verbose logging</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -8,6 +8,18 @@
             android:defaultValue="true"
             android:widgetLayout="@layout/switch_compat"/>
         <CheckBoxPreference
+            android:key="pref_blacklist_sender_id_alphanumeric"
+            android:title="@string/pref_blacklist_sender_id_alphanumeric"
+            android:summary="@string/pref_blacklist_sender_id_alphanumeric_summary"
+            android:defaultValue="false"
+            android:widgetLayout="@layout/switch_compat"/>
+        <CheckBoxPreference
+            android:key="pref_blacklist_sender_id_phone"
+            android:title="@string/pref_blacklist_sender_id_phone"
+            android:summary="@string/pref_blacklist_sender_id_phone_summary"
+            android:defaultValue="false"
+            android:widgetLayout="@layout/switch_compat"/>
+        <CheckBoxPreference
             android:key="pref_whitelist_contacts"
             android:title="@string/pref_whitelist_contacts"
             android:summary="@string/pref_whitelist_contacts_summary"


### PR DESCRIPTION
Hi, first of all thank you for the great app. 

Since I am its active user I decided to offer an improvement. The whole thing is about blocking SMS spam from advertising companies and scammers more efficiently. Currently app's default strategy can be called "enable everything that is not explicitly blocked". I personally think that SMS messages today have too little use cases, and using this strategy will require user to put a significant effort in setting up blacklist rules and some spam will still get through.

I do not use SMS to send texts, because I communicate with all people in messengers, like most folks nowadays probably. Perhaps once in a year I can receive an SMS from a friend or a family if they have missed the payment for the internet on a SIM card and have to write a normal SMS, but it will certainly be people from my contact list. There are exactly zero cases when I need to expect an SMS from an unknown phone number. I really need to receive a normal SMS from an alphanumeric sender sometimes, when I need to get a 2FA or a confirmation code, but all these senders are known to me and I can easily whitelist them. So to summarize it all, in my case 95% of all times I get an SMS means I got a spam that distracts me from my business and that is frustrating. 

In my country SMS spam is big problem and spammers use two main strategies: 
- Send spam from mailing services that can set an alphanumeric SenderID instead of a regular phone number. Such messages cannot be entirely blocked on both iOS and Android, since both operating systems consider such messages important and spammers know that. Even if you explicitly block the sender ID, the next time it sends you a spam message you will just avoid the sound notification, but the message itself will still be delivered to a SMS mailbox and you will have to delete it manually, and read it in process anyway (that was the reason I started to use NekoSMS at the first place). The typical spammer in this case is a legal business that annoys its customers with offers, sales, etc.
- Send spam from a valid phone number, but the number itself is a one-time number from a huge pool. Typical spammers in this case are scammers of all sorts, unscrupulous advertisers, illegal casinos etc. They bombard selected numbers with SMS but change phone number after every message, this makes it impossible to block them, since blacklist on Android can only accept one number at a time, no masks, regular expressions etc. 

The solution for this problem I think is to give user an opportunity to use the strategy "block everything that is not explicitly enabled". 

I added two checkbox options in the settings menu of the app. First will block all incoming SMS from alphanumeric SenderIDs by default unless there is a whitelist rule that explicitly allows this SenderID to send user an SMS. This allows you to ignore most of random advertising from companies that got your number somewhere and decided to impose their services to random people. And it also solves the problem of granular permissions of SMS contents. For example I want to see 2FA codes that my bank sends me in SMS, so I gonna create a whitelist rule with bank's SenderID and word "code" in message body and I will get those codes. But I know that the bank will also occasionally push me the advertisement of their services and that is surely something I don't want to see, so with this approach I don't even have to do anything to get rid from this kind of spam - very convenient. Second checkbox will block all incoming SMS from phone numbers unless there are explicit whitelist rules or the checkbox "whitelist contacts" is on. This perfectly solves the problem with scammers. As I mentioned I never expect SMS messages from strangers and people that I know will still be able to send me a normal SMS if they will decide to do so for some reason.

Both checkboxes are optional and disabled by default, so user experience remains the same, but people will get an opportunity to use new approach in blocking SMS spam on their devices. I think it will improve user experience in most cases and it makes the app cover 90% of everything a typical user expects from such application straight out of the box. People who want to use normal approach with manual blocking can just ignore new options and continue to use the app as before. 

I tested both options, including cases when sender is in the contact list or in a whitelist rule. Everything works great.

Here is how it looks:

![Screenshot_20210912-191758_NekoSMS](https://user-images.githubusercontent.com/9579364/132996305-f7c1d6d8-ed12-427e-a233-ae6f50ed27b6.png)

Hope this change will make its way to the master branch and thank you again!