### PR TITLE
Fix the bug that Android11+ subId is always 0

### DIFF
--- a/app/src/main/java/com/crossbowffs/nekosms/data/SmsMessageData.java
+++ b/app/src/main/java/com/crossbowffs/nekosms/data/SmsMessageData.java
@@ -3,7 +3,10 @@ package com.crossbowffs.nekosms.data;
 import android.content.ContentUris;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.telephony.SmsMessage;
+import android.telephony.SubscriptionManager;
+
 import com.crossbowffs.nekosms.provider.DatabaseContract;
 import com.crossbowffs.nekosms.utils.SmsMessageUtils;
 
@@ -25,7 +28,13 @@ public class SmsMessageData {
         String body = SmsMessageUtils.getMessageBody(messageParts);
         long timeSent = messageParts[0].getTimestampMillis();
         long timeReceived = System.currentTimeMillis();
-        int subId = SmsMessageUtils.getSubId(messageParts[0]);
+        int subId = SmsMessageUtils.getSubId(messageParts[0]);//Android 11 测试始终为0
+
+        // 高版本android，换种获取sub_id的途径
+        // 参考了 Telephony.Sms.Intents.getMessagesFromIntent(intent)的方法体中获取subId的方法
+        if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.O){
+            subId = intent.getIntExtra(SubscriptionManager.EXTRA_SUBSCRIPTION_INDEX,0);
+        }
 
         SmsMessageData message = new SmsMessageData();
         message.setSender(Normalizer.normalize(sender, Normalizer.Form.NFC));

--- a/app/src/main/java/com/crossbowffs/nekosms/xposed/SmsHandlerHook.java
+++ b/app/src/main/java/com/crossbowffs/nekosms/xposed/SmsHandlerHook.java
@@ -12,7 +12,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.UserHandle;
 import android.provider.Telephony;
-import android.telephony.SmsMessage;
 import android.telephony.SubscriptionManager;
 
 import com.crossbowffs.nekosms.BuildConfig;
@@ -21,16 +20,21 @@ import com.crossbowffs.nekosms.consts.PreferenceConsts;
 import com.crossbowffs.nekosms.data.SmsMessageData;
 import com.crossbowffs.nekosms.filters.SmsFilterLoader;
 import com.crossbowffs.nekosms.loader.BlockedSmsLoader;
-import com.crossbowffs.nekosms.utils.*;
+import com.crossbowffs.nekosms.utils.AppOpsUtils;
+import com.crossbowffs.nekosms.utils.ContactUtils;
+import com.crossbowffs.nekosms.utils.ReflectionUtils;
+import com.crossbowffs.nekosms.utils.StringUtils;
+import com.crossbowffs.nekosms.utils.Xlog;
 import com.crossbowffs.remotepreferences.RemotePreferenceAccessException;
 import com.crossbowffs.remotepreferences.RemotePreferences;
+
+import java.lang.reflect.Method;
+
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
-
-import java.lang.reflect.Method;
 
 public class SmsHandlerHook implements IXposedHookLoadPackage {
     private class ConstructorHook extends XC_MethodHook {
@@ -203,6 +207,20 @@ public class SmsHandlerHook implements IXposedHookLoadPackage {
         }
     }
 
+    // override the subId value in the intent with the values from tracker as they can be
+    // different, specifically if the message is coming from SmsBroadcastUndelivered
+    private void putSubscriptionIdExtra(Intent intent, int subId) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                if((boolean) XposedHelpers.callStaticMethod(SubscriptionManager.class, "isValidSubscriptionId", subId)){
+                    XposedHelpers.callStaticMethod(SubscriptionManager.class, "putSubscriptionIdExtra", intent, subId);
+                }
+            } catch (Exception e) {
+                Xlog.e("Could not update intent with subId", e);
+            }
+        }
+    }
+
     private void beforeDispatchIntentHandler(XC_MethodHook.MethodHookParam param, int receiverIndex) {
         Intent intent = (Intent)param.args[0];
         String action = intent.getAction();
@@ -223,6 +241,12 @@ public class SmsHandlerHook implements IXposedHookLoadPackage {
         // to the intent, so we have to emulate that behavior ourselves
         // if we want to use the field.
         putPhoneIdAndSubIdExtra(param.thisObject, intent);
+
+        // android 11+ new
+        // see http://www.aospxref.com/android-11.0.0_r21/xref/frameworks/opt/telephony/src/java/com/android/internal/telephony/InboundSmsHandler.java#1266
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R){
+            putSubscriptionIdExtra(intent, (int) param.args[6]);
+        }
 
         SmsMessageData message = SmsMessageData.fromIntent(intent);
         String sender = message.getSender();


### PR DESCRIPTION
具体BUG：
使用Android11时发现拦截的短信的subId（SIM卡标号）记录均为0。恢复后在系统短信APP中也不显示具体的SIM卡。

修改说明：
1、优化Android v30+ 时subId的附加处理。参见
http://www.aospxref.com/android-11.0.0_r21/xref/frameworks/opt/telephony/src/java/com/android/internal/telephony/InboundSmsHandler.java#1266    
2、优化Android v26+从intent中取得subId的方法。

测试结果：
![image](https://user-images.githubusercontent.com/6801952/179367344-46152efd-8fd0-4f68-b771-bf10ddbeb813.png)
